### PR TITLE
feat: added opitonal option paramteter for composable

### DIFF
--- a/src/runtime/composables/useClientStripe.ts
+++ b/src/runtime/composables/useClientStripe.ts
@@ -1,7 +1,7 @@
 import { onMounted, useNuxtApp, useState } from "#imports"
 import { loadStripe } from '@stripe/stripe-js'
 
-import type { Stripe } from '@stripe/stripe-js'
+import type { Stripe, StripeConstructorOptions } from '@stripe/stripe-js'
 /**
  * useClientStripe function
  *
@@ -9,7 +9,7 @@ import type { Stripe } from '@stripe/stripe-js'
  * It can be used in components or pages to interact with the Stripe.js library.
  *
  */
-export default async function useClientStripe() {
+export default async function useClientStripe(options?: StripeConstructorOptions) {
   const nuxtApp = useNuxtApp()
   const stripe = useState<Stripe>('stripe-client', () => null)
   const isLoading = useState('stripe-client-loading', () => false)
@@ -22,11 +22,17 @@ export default async function useClientStripe() {
     isLoading.value = true
 
     if (!nuxtApp.$config.public.stripe.key) console.warn("no key given for Stripe client service")
-
-    return await loadStripe(
-      nuxtApp.$config.public.stripe.key,
-      nuxtApp.$config.public.stripe.options
-    )
+    if(options) {
+      return await loadStripe(
+        nuxtApp.$config.public.stripe.key,
+        options
+      )
+    } else {
+      return await loadStripe(
+        nuxtApp.$config.public.stripe.key,
+        nuxtApp.$config.public.stripe.options
+      )
+    }
   }
 
   onMounted(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
It is now possible to give aobject by the type of StripeConstructorOptions to the function useClientStripe
<!--- Why is this change required? What problem does it solve? -->
This can help to make request with different StripeConnectAccounts on the frontend rather to stick only to the one defined in nuxt.config.ts

<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
https://github.com/fuentesloic/nuxt-stripe/issues/30

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
 I would update the Documentation by myself if some one points out where i can change it
- [ ] I have added tests to cover my changes (if not applicable, please state why)
Sadly i couldnt write a successful test because i tried to make a second component where the option parameter is used and somehow the component wasnt rendered (there arent any errors) The same code works for my private project
If someone could give me hint i would appreciate it
